### PR TITLE
Ephemeral faas

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/bionic64"
   config.vm.provision :shell, path: "bootstrap.sh",
-    run: "always"
+    run: "never"
 end

--- a/project/src/func.cpp
+++ b/project/src/func.cpp
@@ -2,6 +2,7 @@
 #include <sys/time.h>
 
 #include "func.h"
+#include "kv_tags.h"
 
 using warble::FollowReply;
 using warble::FollowRequest;
@@ -16,15 +17,11 @@ using warble::Warble;
 using warble::WarbleReply;
 using warble::WarbleRequest;
 
-// Identifiers that specify which string is prepended to the key before adding
-// to key value store
-const std::string kUserFollowing = "user_following:";
-const std::string kUserFollower = "user_follower:";
-const std::string kWarblePost = "warble_post:";
-const std::string kWarbleChildren = "warble_children:";
-
-// prefix used to read and write latest warble from kvstore
-const std::string kLatestWarbleString = "latest_warble_id:";
+using kv_tags::kLatestWarbleString;
+using kv_tags::kUserFollower;
+using kv_tags::kUserFollowing;
+using kv_tags::kWarbleChildren;
+using kv_tags::kWarblePost;
 
 Func::Func() {}
 

--- a/project/src/func.h
+++ b/project/src/func.h
@@ -58,6 +58,12 @@ class Func {
   std::unordered_map<EventType, std::string> function_map_;
   std::mutex mtx_;
 
+  // retrieves latest warble added recorded in kv store
+  int getLatestWarbleId(const Database &kv_client_) const;
+
+  // updates latestWarbleId on every new warble
+  void incrementLatestWarbleId(Database &kv_client_);
+
   warble::RegisteruserReply registeruserEvent(Database &kv_client_,
                                               google::protobuf::Any &payload,
                                               Status &status);
@@ -75,7 +81,8 @@ class Func {
   warble::WarbleReply buildWarbleReplyFromRequest(
       warble::WarbleRequest &request, int id);
 
-  void postWarble(const warble::Warble &warb, Database &kv_client_);
+  void postWarble(const warble::Warble &warb, Database &kv_client_,
+                  int latest_warble_id);
 
   // recursively gets warble children
   void retrieveThreadIds(int id, std::unordered_set<int> &warble_thread,

--- a/project/src/key_value_store_main.cpp
+++ b/project/src/key_value_store_main.cpp
@@ -5,6 +5,9 @@ void RunServer() {
   std::string server_address("0.0.0.0:50001");
   KeyValueStoreServer service;
 
+  // set the latest warble ID as 0
+  service.setup();
+
   ServerBuilder builder;
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
   builder.RegisterService(&service);

--- a/project/src/key_value_store_server.cpp
+++ b/project/src/key_value_store_server.cpp
@@ -1,5 +1,7 @@
 #include "key_value_store_server.h"
 
+const std::string kLatestWarbleString = "latest_warble_id:";
+
 Status KeyValueStoreServer::put(ServerContext* context,
                                 const PutRequest* request, PutReply* response) {
   bool put_success = kv_store_.put(request->key(), request->value());
@@ -36,4 +38,15 @@ Status KeyValueStoreServer::remove(ServerContext* context,
                                    RemoveReply* response) {
   kv_store_.remove(request->key());
   return Status::OK;
+}
+
+Status KeyValueStoreServer::setup() {
+  bool put_success = kv_store_.put(kLatestWarbleString, std::to_string(0));
+  if (put_success) {
+    std::cout << "Put 0 in kvstore" << std::endl;
+    return Status::OK;
+  } else {
+    LOG(ERROR) << "Put initial 0 in KeyValueStoreServer failed" << std::endl;
+    return Status::CANCELLED;
+  }
 }

--- a/project/src/key_value_store_server.cpp
+++ b/project/src/key_value_store_server.cpp
@@ -43,7 +43,6 @@ Status KeyValueStoreServer::remove(ServerContext* context,
 Status KeyValueStoreServer::setup() {
   bool put_success = kv_store_.put(kLatestWarbleString, std::to_string(0));
   if (put_success) {
-    std::cout << "Put 0 in kvstore" << std::endl;
     return Status::OK;
   } else {
     LOG(ERROR) << "Put initial 0 in KeyValueStoreServer failed" << std::endl;

--- a/project/src/key_value_store_server.cpp
+++ b/project/src/key_value_store_server.cpp
@@ -1,6 +1,7 @@
 #include "key_value_store_server.h"
+#include "kv_tags.h"
 
-const std::string kLatestWarbleString = "latest_warble_id:";
+using kv_tags::kLatestWarbleString;
 
 Status KeyValueStoreServer::put(ServerContext* context,
                                 const PutRequest* request, PutReply* response) {

--- a/project/src/key_value_store_server.h
+++ b/project/src/key_value_store_server.h
@@ -31,6 +31,8 @@ class KeyValueStoreServer final : public KeyValueStore::Service {
              ServerReaderWriter<GetReply, GetRequest>* stream) override;
   Status remove(ServerContext* context, const RemoveRequest* request,
                 RemoveReply* response) override;
+  // method that initializes the latest warble as 0
+  Status setup();
 
  private:
   KvStore kv_store_;

--- a/project/src/kv_tags.h
+++ b/project/src/kv_tags.h
@@ -1,0 +1,16 @@
+#ifndef KV_TAGS_H
+#define KV_TAGS_H
+
+namespace kv_tags {
+// Identifiers that specify which string is prepended to the key before adding
+// to key value store
+const std::string kUserFollowing = "user_following:";
+const std::string kUserFollower = "user_follower:";
+const std::string kWarblePost = "warble_post:";
+const std::string kWarbleChildren = "warble_children:";
+
+// prefix used to read and write latest warble from kvstore
+const std::string kLatestWarbleString = "latest_warble_id:";
+}  // namespace kv_tags
+
+#endif

--- a/project/src/warble_main.cpp
+++ b/project/src/warble_main.cpp
@@ -1,4 +1,5 @@
 #include <gflags/gflags.h>
+#include <glog/logging.h>
 #include <time.h>
 
 #include "func_client.h"
@@ -54,6 +55,7 @@ void renderWarbleThread(
 // and executed. Holds a FuncClient which talks to FuncServer
 int main(int argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+  google::InitGoogleLogging(argv[0]);
 
   FuncClient func_client(
       grpc::CreateChannel(kFuncClientPort, grpc::InsecureChannelCredentials()));

--- a/project/test/fake_key_value_store.cpp
+++ b/project/test/fake_key_value_store.cpp
@@ -1,8 +1,9 @@
 #include <iostream>
 
 #include "fake_key_value_store.h"
+#include "kv_tags.h"
 
-const std::string kLatestWarbleString = "latest_warble_id:";
+using kv_tags::kLatestWarbleString;
 
 void FakeKeyValueStoreClient::put(const std::string& key,
                                   const std::string& value) {

--- a/project/test/fake_key_value_store.cpp
+++ b/project/test/fake_key_value_store.cpp
@@ -2,6 +2,8 @@
 
 #include "fake_key_value_store.h"
 
+const std::string kLatestWarbleString = "latest_warble_id:";
+
 void FakeKeyValueStoreClient::put(const std::string& key,
                                   const std::string& value) {
   if (map_.find(key) == map_.end()) {
@@ -32,4 +34,8 @@ const std::vector<GetReply> FakeKeyValueStoreClient::get(
     get_replies.push_back(reply);
   }
   return get_replies;
+}
+
+void FakeKeyValueStoreClient::setup() {
+  put(kLatestWarbleString, std::to_string(0));
 }

--- a/project/test/fake_key_value_store.h
+++ b/project/test/fake_key_value_store.h
@@ -10,6 +10,7 @@ class FakeKeyValueStoreClient : public Database {
   void put(const std::string& key, const std::string& value) override;
   void remove(const std::string& key) override;
   const std::vector<GetReply> get(const std::string& key) const override;
+  void setup();
 
  private:
   std::unordered_map<std::string, std::vector<std::string>> map_;

--- a/project/test/fake_key_value_store.h
+++ b/project/test/fake_key_value_store.h
@@ -7,9 +7,16 @@
 
 class FakeKeyValueStoreClient : public Database {
  public:
+  // Inserts key value pair (duplicate key is okay)
   void put(const std::string& key, const std::string& value) override;
+
+  // Removes all values associated with key
   void remove(const std::string& key) override;
+
+  // Returns all associated values for key
   const std::vector<GetReply> get(const std::string& key) const override;
+
+  // Initializes the latest warble id in kv_store as 0
   void setup();
 
  private:

--- a/project/test/test_func.cpp
+++ b/project/test/test_func.cpp
@@ -1,5 +1,6 @@
 #include "test_func.h"
 #include "fake_key_value_store.h"
+#include "kv_tags.h"
 
 using warble::FollowReply;
 using warble::FollowRequest;
@@ -14,10 +15,10 @@ using warble::WarbleRequest;
 
 // Identifiers that specify which string is prepended to the key before adding
 // to key value store
-const std::string kUserFollowing = "user_following:";
-const std::string kUserFollower = "user_follower:";
-const std::string kWarblePost = "warble_post:";
-const std::string kWarbleChildren = "warble_children:";
+using kv_tags::kUserFollower;
+using kv_tags::kUserFollowing;
+using kv_tags::kWarbleChildren;
+using kv_tags::kWarblePost;
 
 FuncTest::FuncTest() {
   fake_kv = FakeKeyValueStoreClient();

--- a/project/test/test_func.cpp
+++ b/project/test/test_func.cpp
@@ -21,6 +21,8 @@ const std::string kWarbleChildren = "warble_children:";
 
 FuncTest::FuncTest() {
   fake_kv = FakeKeyValueStoreClient();
+  fake_kv.setup();
+
   std::unordered_map<int, std::string> function_map(
       {{Func::EventType::RegisterUser, "registeruser"},
        {Func::EventType::Warble, "warble"},


### PR DESCRIPTION
I tested if faas was truly ephemeral by terminating the faas after every request to warble_main and making sure the service still ran as expected.

I also did not write additional tests since my existing tests checked for warble IDs so the new functionality (in making it ephemeral) was already implicitly tested. Writing new tests would have been redundant and bloated the testing code. 